### PR TITLE
Improve null handling and one-hot encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ SupervisedDataframe has tools to operate on the training and the validation set 
 - Creating grouped statistics (mean, median, var) based on the categorical columns of the training set
 - One hot encoding and scaling
 
+## Usage notes before model training
+
+To keep train/test alignment intact while preparing your data:
+- Run `check_nulls(erase=True)` to drop only training rows that contain missing feature values (the test set is never truncated). The method prints the per-column NA counts for the train and test splits to help you decide whether deletion or imputation is appropriate.
+- Run `to_one_hot([...])` after defining your categorical feature list. One-hot columns are fit on the training categories and reindexed so the test set always has the same columns (unseen test categories are safely ignored instead of shifting columns).
+
 ## The Data
 
 The data we will work on in this project are:


### PR DESCRIPTION
## Summary
- update one-hot encoding to fit categories on training data and keep test columns aligned
- enhance null checking to show per-split NA counts and only drop training rows when requested
- document safe usage of preprocessing helpers before model training

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d6764a9c832abf56c76c14807644)