### PR TITLE
Limit salary cleaning to training data and verify test size

### DIFF
--- a/HRdataNotebook.ipynb
+++ b/HRdataNotebook.ipynb
@@ -125,8 +125,10 @@
     "    \n",
     "    print(\"Creating new Supervised Dataframe instance...\")\n",
     "    hr_data = SupervisedDataframe(train_src, test_src, target_src)\n",
+    "    original_test_rows = len(hr_data.merged.loc[\"test\"])\n",
     "    print(\"Erasing non-positive salaries...\")\n",
-    "    hr_data.merged.loc[\"train\"] = hr_data.merged[hr_data.merged[\"salary\"] > 0]\n",
+    "    train_slice = hr_data.merged.loc[\"train\"]\n",
+    "    hr_data.merged.loc[\"train\"] = train_slice[train_slice[\"salary\"] > 0]\n",
     "    print(\"Erasing useless features companyId and JobId...\")\n",
     "    hr_data.merged = hr_data.merged.drop(columns=[\"companyId\",\"jobId\"])\n",
     "    print(\"Creating group statistics out of categories...\")\n",
@@ -138,11 +140,13 @@
     "    hr_data.scale(num_to_scale, method=\"standard\")\n",
     "    print(\"Binarizing the categorical features...\")\n",
     "    hr_data.to_one_hot(categories)\n",
+    "    current_test_rows = len(hr_data.merged.loc[\"test\"])\n",
+    "    assert current_test_rows == original_test_rows, \"Test row count changed during cleaning\"\n",
     "    print(\"Return features, target and test features...\")\n",
     "    feat_train, target_train = hr_data.split_feature_target()\n",
     "    feat_test = hr_data.get_test()\n",
     "    print(\"Done!\")\n",
-    "    return feat_train, target_train, feat_test"
+    "    return feat_train, target_train, feat_test\n"
    ]
   },
   {
@@ -2301,7 +2305,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 36 columns</p>\n",
+       "<p>5 rows \u00d7 36 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2561,7 +2565,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 36 columns</p>\n",
+       "<p>5 rows \u00d7 36 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2961,7 +2965,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>8 rows × 29 columns</p>\n",
+       "<p>8 rows \u00d7 29 columns</p>\n",
        "</div>"
       ],
       "text/plain": [


### PR DESCRIPTION
## Summary
- limit the short_track salary cleaning step to the training split
- track and assert that the test set row count remains unchanged through preprocessing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953dd28df28832a94db0fb1d1a47cc9)