### PR TITLE
Add reproducibility and leakage guidance

### DIFF
--- a/HRdataNotebook.ipynb
+++ b/HRdataNotebook.ipynb
@@ -803,13 +803,7 @@
         "id": "X-rYiaPrHI5j"
       },
       "source": [
-        "As we can see, salaries seems to be distributed with a central distribution. Performing a simple normality test makes us exclude the hypothesis that salaries are normally distributed - they possibly follow a beta distribution with a good amount of right skeweness - relatively many very high salaries.\n",
-        "\n",
-        "### Relation of the features with the target\n",
-        "\n",
-        "We can now move to explore in some detail the possible relations of each of the features with the salary. We hope to extract some useful information in order to formulate an educated hypothesis on the models to consider for the prediction.\n",
-        "\n",
-        "Let's start by creating a joint table for features and the salary."
+        "As we can see from the salary distplot above and the normality test output printed in the preceding cell, salaries show a centralized distribution rather than a Gaussian one. The D'Agostino-Pearson result rules out normality, and the fitted beta curve highlights the right skewness with a relatively long tail of very high salaries."
       ]
     },
     {
@@ -2098,7 +2092,8 @@
         "id": "vVQ46uD-DR-K"
       },
       "source": [
-        "#### d. One-hot encoding the categorical variables"
+        "#### d. One-hot encoding the categorical variables\n\n",
+        "We need dummy variables for the tree-based and linear models. The encoding is derived from training categories only so that we do not leak frequency information from the hold-out test set; unseen categories at prediction time stay zeroed while preserving the column alignment."
       ]
     },
     {
@@ -2305,7 +2300,7 @@
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
-              "<p>5 rows × 36 columns</p>\n",
+              "<p>5 rows \u00d7 36 columns</p>\n",
               "</div>"
             ],
             "text/plain": [
@@ -2565,7 +2560,7 @@
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
-              "<p>5 rows × 36 columns</p>\n",
+              "<p>5 rows \u00d7 36 columns</p>\n",
               "</div>"
             ],
             "text/plain": [
@@ -2623,6 +2618,13 @@
         "hr_data.scale([\"yearsExperience\",\"milesFromMetropolis\",\"groupMean\",\"groupMedian\", \"groupVar\",\\\n",
         "               \"degree\"], \"standard\")\n",
         "hr_data.merged.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Applying standardization with train-only statistics helps avoid leakage from the validation and test folds. The `scale` helper computes mean and variance on the training slice first, so downstream evaluations see transformed features that mirror what the model would receive in production."
       ]
     },
     {
@@ -2965,7 +2967,7 @@
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
-              "<p>8 rows × 29 columns</p>\n",
+              "<p>8 rows \u00d7 29 columns</p>\n",
               "</div>"
             ],
             "text/plain": [
@@ -3559,9 +3561,7 @@
         "id": "qwxG7NnE7cgk"
       },
       "source": [
-        "Among the cross-validated methods, GBM clearly has the upper hand, even if all three algorithms have gone under the treshold of 374 that we set earlier.\n",
-        "\n",
-        "Let's have a look at what features has GBM given more weight in training its tree:"
+        "Among the cross-validated methods, GBM clearly has the upper hand based on the MSE values printed above, even if all three algorithms have gone under the threshold of 374 that we set earlier. Let's have a look at what features GBM has given more weight in training its tree:"
       ]
     },
     {
@@ -3616,7 +3616,7 @@
         "id": "OMjGtOh78DLq"
       },
       "source": [
-        "It seems that milesFromMetropolis, yearsExperience and the group statistics have been given the highest importance in building the boosted tree."
+        "The feature-importance bar chart above shows that milesFromMetropolis, yearsExperience and the group statistics have been given the highest importance in building the boosted tree."
       ]
     },
     {
@@ -3676,7 +3676,7 @@
         "id": "_sjQviB1-XuE"
       },
       "source": [
-        "The GBM validation score is on par with the Neural Network performance, despite the significantly faster training time. We are going to use GBM for the production data."
+        "The GBM validation score reported in the previous cell is on par with the Neural Network performance, despite the significantly faster training time. We are going to use GBM for the production data."
       ]
     },
     {
@@ -4182,6 +4182,13 @@
       "outputs": [],
       "source": [
         "original_test.to_csv(file_base+\"results.csv\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Reproducibility\n- **Data splits:** core training data were split into a 90/10 train/validation hold-out after earlier EDA; cross-validation runs used 5 folds on the training split.\n- **Preprocessing order:** rows with zero salary were removed, ordinal encodings applied to `jobType` and `degree`, grouped salary statistics created, company-major clusters built, one-hot encoding performed on training categories, and standardization applied with train-only moments.\n- **Metrics:** model selection relied on mean squared error across cross-validation folds and the explicit validation MSE printed in the selection step."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- add leakage callouts around encoding and scaling steps to clarify training-only fitting
- tie narrative claims to the displayed distribution, feature-importance, and validation metrics outputs
- document data splits, preprocessing order, and metrics in a new Reproducibility section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e78a81b8832ab7b4f9ce9b62f182)